### PR TITLE
OpenStruct needs explicit root namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: ruby
 rvm:
+  - 2.4.1
   - 2.1.2
   - 2.0.0
-  - 1.9.3
-  - 1.9.2
 
-  - rbx-19mode
   - ruby-head
   - jruby-19mode
 
@@ -19,6 +17,5 @@ script: bundle exec ruby spec/log_spec.rb
 
 matrix:
   allow_failures:
-    - rvm: rbx-19mode
     - rvm: ruby-head
     - rvm: jruby-19mode

--- a/lib/logsaber/options.rb
+++ b/lib/logsaber/options.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 
 module Logsaber
-  class Options < OpenStruct
+  class Options < ::OpenStruct
     def self.extract_from args, defaults = {}, primary = nil
       options = args.last.is_a?(Hash) ? args.pop : Hash.new
       options[primary] = args.shift if primary && args.first


### PR DESCRIPTION
Encountered this error in Ruby 2.4.1:
`Gem Load Error is: uninitialized constant Logsaber::OpenStruct`